### PR TITLE
Fix site styling and modal behavior

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1912,23 +1912,19 @@ body {
 }
 
 .nav-btn {
-    background: rgba(255, 255, 255, 0.25); /* Increased opacity */
+    background: rgba(26, 26, 26, 0.2);
     backdrop-filter: blur(20px);
     -webkit-backdrop-filter: blur(20px);
-    border: 2px solid rgba(255, 255, 255, 0.3); /* Stronger border */
-    border-radius: 12px;
-    padding: 15px 25px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 15px;
+    padding: 20px 30px;
     color: var(--text-primary);
-    font-size: 1rem;
-    font-weight: 800 !important; /* Even bolder text */
+    font-size: 1.2rem;
+    font-weight: 700;
     cursor: pointer;
     transition: all 0.3s ease;
-    box-shadow: 
-        0 15px 45px rgba(0, 0, 0, 0.7), /* Stronger shadows */
-        0 8px 25px rgba(0, 0, 0, 0.5),
-        inset 0 2px 0 rgba(255, 255, 255, 0.4);
+    box-shadow: 0 15px 35px rgba(0, 0, 0, 0.4);
     text-align: center;
-    text-shadow: 2px 2px 6px rgba(0, 0, 0, 0.9); /* Stronger text shadow */
 }
 
 .nav-btn:hover,

--- a/index.html
+++ b/index.html
@@ -373,19 +373,6 @@
 
         <!-- Live Demos Section -->
         <section id="demos" class="section">
-            <div class="section-header">
-                <h2>Live Demos</h2>
-                <p style="color: var(--text-secondary); max-width: 600px; margin: 0 auto;">Explore my live portfolio and projects in action.</p>
-            </div>
-
-            <div class="demos-container">
-                <div class="demo-card">
-                    <div class="demo-icon">🌟</div>
-                    <h3>Personal Portfolio</h3>
-                    <p>My complete personal portfolio showcasing all my projects, skills, and experience.</p>
-                    <button id="portfolio-demo-btn" class="btn btn-primary">View Live Demo</button>
-                </div>
-            </div>
         </section>
 
         <!-- Blog Generator Section -->
@@ -445,50 +432,41 @@
         <!-- Live Demo Modal Structure -->
         <div id="live-demo-modal" class="modal">
             <div class="modal-content">
-                <span class="modal-close" onclick="closeLiveDemoModal()">&times;</span>
+                <span class="modal-close">&times;</span>
                 <div class="modal-body">
                     <div class="demo-modal-header">
                         <h2>🌟 Personal Portfolio - Live Demo</h2>
-                        <p>Explore my complete portfolio website with all features and projects.</p>
+                        <p>This is a live demonstration of my personal portfolio website. It showcases my skills, projects, and professional experience in a clean, modern interface. The site is fully responsive and designed with a glassmorphism aesthetic.</p>
                     </div>
                     
                     <div class="demo-info">
                         <div class="demo-details">
-                            <h3>Portfolio Features:</h3>
+                            <h3>Key Features:</h3>
                             <ul>
-                                <li>✨ Modern glassmorphism design</li>
-                                <li>🚀 Interactive project showcase</li>
-                                <li>📱 Fully responsive layout</li>
-                                <li>🎨 Dynamic theme switching</li>
-                                <li>⚡ Fast loading performance</li>
-                                <li>🔍 Advanced project filtering</li>
+                                <li>✨ **Interactive Design:** A visually appealing layout with smooth animations and transitions.</li>
+                                <li>🚀 **Project Showcase:** Detailed view of my projects with descriptions, technologies used, and links.</li>
+                                <li>📱 **Fully Responsive:** Adapts seamlessly to all screen sizes, from mobile phones to desktops.</li>
+                                <li>🎨 **Dynamic Theme Switching:** Allows users to switch between dark, light, and neon themes.</li>
+                                <li>⚡ **Performance Optimized:** Built for speed with fast loading times and efficient code.</li>
                             </ul>
                         </div>
                         
                         <div class="demo-tech-stack">
-                            <h3>Technologies Used:</h3>
+                            <h3>Core Technologies:</h3>
                             <div class="tech-tags">
                                 <span class="tech-tag">HTML5</span>
                                 <span class="tech-tag">CSS3</span>
-                                <span class="tech-tag">JavaScript</span>
-                                <span class="tech-tag">Glassmorphism</span>
+                                <span class="tech-tag">JavaScript (ES6+)</span>
                                 <span class="tech-tag">Responsive Design</span>
+                                <span class="tech-tag">Flexbox & Grid</span>
                             </div>
                         </div>
                     </div>
                     
                     <div class="demo-actions">
-                        <button id="view-portfolio-btn" class="btn btn-primary">
-                            🔗 Click to View Portfolio
-                        </button>
-                        <div id="portfolio-loading" class="loading-message" style="display: none;">
-                            <div class="loading-spinner"></div>
-                            <p>Loading portfolio...</p>
-                        </div>
-                    </div>
-                    
-                    <div id="portfolio-frame-container" class="portfolio-frame-container" style="display: none;">
-                        <iframe id="portfolio-frame" src="" frameborder="0"></iframe>
+                        <a href="https://garymike07.github.io/myk/" target="_blank" class="btn btn-primary">
+                            🔗 View Live Site
+                        </a>
                     </div>
                 </div>
             </div>

--- a/js/main.js
+++ b/js/main.js
@@ -33,7 +33,11 @@ class MikeSites {
             btn.addEventListener("click", (e) => {
                 e.preventDefault();
                 const section = btn.getAttribute("data-section");
-                this.navigateToSection(section);
+                if (section === 'demos') {
+                    this.openModal('live-demo-modal');
+                } else {
+                    this.navigateToSection(section);
+                }
             });
         });
 
@@ -190,10 +194,6 @@ class MikeSites {
         switch (sectionName) {
             case 'projects':
                 // Projects are now loaded directly on the home page
-                break;
-            case 'demos':
-                // Load live demos content
-                this.loadLiveDemos();
                 break;
             case 'tech-stack':
                 this.animateProficiencyBars();
@@ -576,34 +576,5 @@ document.addEventListener('DOMContentLoaded', () => {
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = MikeSites;
 }
-
-
-
-    loadLiveDemos() {
-        const demosContainer = document.querySelector("#demos .demos-container");
-        if (demosContainer) {
-            demosContainer.innerHTML = `
-                <h2>Live Demos</h2>
-                <p>Explore interactive live demonstrations of my projects.</p>
-                <div class="demo-grid">
-                    <div class="demo-card">
-                        <h3>Project Alpha</h3>
-                        <p>A cutting-edge SaaS platform.</p>
-                        <a href="#" class="btn btn-primary">View Demo</a>
-                    </div>
-                    <div class="demo-card">
-                        <h3>Project Beta</h3>
-                        <p>An e-commerce solution with advanced features.</p>
-                        <a href="#" class="btn btn-primary">View Demo</a>
-                    </div>
-                    <div class="demo-card">
-                        <h3>Project Gamma</h3>
-                        <p>A data visualization dashboard.</p>
-                        <a href="#" class="btn btn-primary">View Demo</a>
-                    </div>
-                </div>
-            `;
-        }
-    }
 
 


### PR DESCRIPTION
This commit addresses several issues with the website:

- The main navigation buttons have been restyled to be larger and more consistent with the site's glassmorphism design.
- The "Live Demos" navigation button now opens a modal with details about the personal portfolio, instead of navigating to a separate section.
- The "Live Demos" section content has been removed as it is no longer needed.
- The personal portfolio modal now contains a detailed description and a direct link to the live site.
- The concept of a "footer" was clarified to be the "Live Demos" section, which has been removed.